### PR TITLE
Don't force installation into /usr

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,6 @@ cmake_minimum_required(VERSION "2.8.4")
 project("${project_name}" C)
 string(TOLOWER "${project_name}" project_name_lower)
 
-set(CMAKE_INSTALL_PREFIX "/usr")
 set(bindir "bin")
 set(datarootdir "share")
 set(libdir "lib")

--- a/guanako/CMakeLists.txt
+++ b/guanako/CMakeLists.txt
@@ -28,7 +28,6 @@ if(project_root)
   set("${project_name}_VERSION" "${${project_name}_VERSION}" PARENT_SCOPE)
 endif()
 
-set(CMAKE_INSTALL_PREFIX "/usr")
 set(bindir "bin")
 set(datarootdir "share")
 set(libdir "lib")


### PR DESCRIPTION
The current build system forces installation into /usr. It makes harder to test the valama.

The commit reverts to default installation path. The current behaviour can be done by

```
cmake -DCMAKE_INSTALL_PREFIX=/usr ...
```
