### PR TITLE
Fixed finding vala with version in filenames

### DIFF
--- a/cmake/vala/FindVala.cmake
+++ b/cmake/vala/FindVala.cmake
@@ -73,7 +73,7 @@
 ##
 
 # Search for the valac executable in the usual system paths.
-find_program(VALA_EXECUTABLE "valac" "valac-0.22" "valac-0.20" "valac-0.18" "valac-0.16" "valac-0.14" "valac-0.12")
+find_program(VALA_EXECUTABLE NAMES "valac" "valac-0.22" "valac-0.20" "valac-0.18" "valac-0.16" "valac-0.14" "valac-0.12")
 mark_as_advanced(VALA_EXECUTABLE)
 
 # Determine the valac version


### PR DESCRIPTION
Build failed on systems when version was appended to valac-.

The problem was solved by using the second and more complete definition of the find_program command.
http://cmake.org/cmake/help/v2.8.8/cmake.html#command:find_program
